### PR TITLE
Minor gains in `parse::line`

### DIFF
--- a/.github/workflows/rust-CI.yml
+++ b/.github/workflows/rust-CI.yml
@@ -23,6 +23,6 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
     - name: Check clippy
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets --features=bench,assert,debug -- -D warnings
     - name: Run tests
       run: cargo test --verbose

--- a/src/parser/models.rs
+++ b/src/parser/models.rs
@@ -253,7 +253,7 @@ impl StationRecords {
                 len = buffer.len()
             );
 
-            line::parse_bytes(buffer, &mut records).await;
+            line::parse_bytes(&buffer[..], &mut records).await;
         }
 
         #[cfg(feature = "debug")]


### PR DESCRIPTION
Down to 9s by removing blocking `Cursor`, and using `read_until` instead of `read_u8`.