### PR TITLE
feature: Blocking `mmap` + `rayon` implementation for baseline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,9 @@ dependencies = [
  "deadqueue",
  "gxhash",
  "itertools",
+ "memmap",
  "nohash",
+ "rayon",
  "tokio",
 ]
 
@@ -155,6 +157,25 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-queue"
@@ -246,6 +267,16 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -342,6 +373,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +471,28 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ name = "io_only"
 path = "src/bin/io_only.rs"
 required-features = ["bench"]
 
+[[bin]]
+name = "mmap_baseline"
+path = "src/bin/mmap_baseline.rs"
+required-features = ["sync"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -22,7 +27,9 @@ clap = { version = "4.5.1", features = ["derive"] }
 deadqueue = "0.2.4"
 gxhash = "3.1.1"
 itertools = "0.12.1"
+memmap = { version = "0.7.0", optional = true }
 nohash = { version = "0.2.0", optional = true }
+rayon = { version = "1.10.0", optional = true }
 tokio = { version = "1.36.0", features = ["rt-multi-thread", "io-std", "macros", "sync", "io-util", "fs", "time"] }
 
 [features]
@@ -36,3 +43,4 @@ nohash = ["dep:nohash"]
 noparse = ["noparse-name", "noparse-value"]
 noparse-name = []
 noparse-value = []
+sync = ["dep:rayon", "dep:memmap"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ even though it may incur runtime overheads.
 ## Setup requirements
 
 - GNU Make, Rust, JDK 21, and Maven should be installed.
+- Compile the Java reference implementation by running `./mvnw clean verify` in
+  the `../1brc` directory.
 - The [`1brc` repository](https://github.com/gunnarmorling/1brc) should be cloned to
   a parallel directory to this repository, i.e. should be accessible at `../1brc`.
     - `./create_measurements.sh 1000000000` should have been run within the `1brc` repository,
@@ -41,6 +43,15 @@ even though it may incur runtime overheads.
 ```sh
 make run
 ```
+
+## Current timings
+
+The timings are taken on a M1 Pro 10-core machine, using only 8 threads.
+
+File is read from disk directly; no RAM disk is used.
+
+- Tokio Buffered Read: `~9.6s`
+- Mmap + Rayon: `~7.3s`
 
 ## Feature Flags
 

--- a/src/bin/io_only.rs
+++ b/src/bin/io_only.rs
@@ -43,13 +43,9 @@ async fn main() {
             _ = reader.read(bufreader) => {},
             _ = async {
                 let mut buffer = Vec::with_capacity(args.max_chunk_size);
-                loop {
-                    if let Some(bytes) = reader.fill(buffer).await {
-                        buffer = bytes;
-                        count += 1;
-                    } else {
-                        break
-                    }
+                while let Some(bytes) = reader.fill(buffer).await {
+                    buffer = bytes;
+                    count += 1;
                 }
             } => {}
         };

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -41,7 +41,7 @@ async fn main() {
 
             reader.read(buffer).await
         },
-        parser::task::read_from_reader(Arc::clone(&reader), args.threads),
+        parser::task::read_from_reader(Arc::clone(&reader), args.threads, args.max_chunk_size),
     );
 
     records.export_file(&args.output).await;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -29,10 +29,10 @@ async fn main() {
     #[cfg(feature = "bench")]
     let start = Instant::now();
 
-    let reader = Arc::new(reader::RowsReader::with_chunk_sizes(
-        args.chunk_size,
-        args.max_chunk_size,
-    ));
+    let reader = Arc::new(
+        reader::RowsReader::with_chunk_sizes(args.chunk_size, args.max_chunk_size)
+            .with_additional_buffers(8),
+    );
 
     let (_, records) = tokio::join!(
         async {

--- a/src/bin/mmap_baseline.rs
+++ b/src/bin/mmap_baseline.rs
@@ -1,0 +1,62 @@
+//! A simple implementation using [`memmap::Mmap`] as well as [`rayon::iter::ParallelIterator`]
+//! to read the file and parse the records in parallel.
+//!
+//! The file is sliced into given number of chunks, equal to the number of threads, then
+//! each chunk creates a [`StationRecords`] instance to parse the records, before reducing
+//! down to a single instance.
+//!
+//! This implementation serves as a baseline for the performance comparison with the async
+//! implementation. This is expected to be faster, but less efficient in terms of memory
+//! usage, and have limited scalability. This also does not support a streaming input
+//! as the async implementation does.
+use clap::Parser;
+use std::time::Instant;
+
+use async_1brc::{parser::models::StationRecords, reader::sync::*, CliArgs};
+
+#[cfg(feature = "assert")]
+use async_1brc::assertion;
+
+fn main() {
+    let args = CliArgs::parse();
+
+    println!(
+        "Parameters:\n\
+        - File: {}",
+        args.file
+    );
+
+    #[cfg(feature = "bench")]
+    let start = Instant::now();
+
+    let reader = MmapReader::from_path(&args.file).with_chunks(args.threads);
+
+    let records = StationRecords::read_from_iterator(reader.iter::<b'\n'>());
+
+    records.export_file_blocking(&args.output);
+
+    #[cfg(feature = "bench")]
+    println!("elapsed time: {:?}", start.elapsed());
+
+    #[cfg(feature = "assert")]
+    '_assertion: {
+        if cfg!(any(
+            feature = "noparse",
+            feature = "noparse-name",
+            feature = "noparse-value"
+        )) {
+            println!("Cannot perform assertions when parsing is partially/fully disabled. Assertion aborted.");
+            return;
+        }
+
+        println!("Checking the number of records...");
+        let output_len = records.len();
+        println!("The number of records: {}", output_len);
+        assert_eq!(output_len, 1_000_000_000);
+
+        println!("Matching the output and the baseline files...");
+        assertion::match_files_blocking(&args.output, &args.baseline);
+
+        println!("All assertions passed.")
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,9 @@ pub mod line;
 
 pub mod models;
 
+#[cfg(feature = "sync")]
+pub mod sync;
+
 pub mod task;
 
 mod hashable_buffer;

--- a/src/parser/models.rs
+++ b/src/parser/models.rs
@@ -19,6 +19,12 @@ pub static HASH_INSERT_TIMED: std::sync::OnceLock<std::sync::Arc<TimedOperation>
 #[cfg(feature = "nohash")]
 pub use std::hash::BuildHasherDefault;
 
+#[cfg(feature = "sync")]
+pub use super::sync;
+
+#[cfg(feature = "sync")]
+use rayon::prelude::*;
+
 /// Statistics of a single station.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StationStats {
@@ -264,6 +270,48 @@ impl StationRecords {
         println!("read_from_reader() finished.");
 
         records
+    }
+
+    /// The main synchronous function to read from a [`Mmap`] and parse the data into itself.
+    #[cfg(feature = "sync")]
+    pub fn read_from_iterator<'m>(
+        chunks: impl Iterator<Item = &'m [u8]> + ParallelBridge + Send,
+    ) -> Self {
+        chunks
+            // Inefficient bridge to parallelize the parsing; we will consider making this
+            // a native [`rayon::iter::ParallelIterator`] in the future.
+            .par_bridge()
+            .map(|chunk| {
+                #[cfg(feature = "debug")]
+                println!(
+                    "read_from_iterator() found {len} bytes of data.",
+                    len = chunk.len()
+                );
+
+                let mut records = Self::new();
+                sync::parse_bytes(chunk, &mut records);
+                records
+            })
+            .reduce(Self::new, |mut records, chunk_records| {
+                records += chunk_records;
+                records
+            })
+    }
+
+    #[cfg(feature = "sync")]
+    /// Export the results to a file in the 1BRC format.
+    pub fn export_file_blocking(&self, path: impl AsRef<Path>) {
+        use std::io::Write;
+
+        #[cfg(feature = "timed")]
+        let _ops = TimedOperation::new("StationRecords::export_file()");
+        #[cfg(feature = "timed")]
+        let _counter = _ops.start();
+
+        let mut file = std::fs::File::create(path).expect("Failed to create the file.");
+
+        file.write(self.export_text().as_bytes())
+            .expect(&format!("Failed to write to the file",));
     }
 }
 

--- a/src/parser/sync.rs
+++ b/src/parser/sync.rs
@@ -1,0 +1,56 @@
+//! Parsing a 1BRC line, synchronously.
+
+use super::{func, models};
+
+/// Parse bytes into a [`models::StationRecords`].
+///
+/// This will parse the bytes into an existing [`models::StationRecords`], potentially local
+/// to the caller's thread.
+///
+/// These parsing functions expect perfect input; if the input is not perfect, the behavior is
+/// undefined.
+#[allow(unreachable_code, unused_variables, unused_mut)]
+pub fn parse_bytes(bytes: &[u8], records: &mut models::StationRecords) {
+    #[cfg(feature = "debug")]
+    let mut counter = 0;
+
+    bytes
+        .split(|&byte| byte == b'\n')
+        .filter(|bytes| bytes.len() > 0)
+        .for_each(|line| {
+            #[cfg(feature = "debug")]
+            '_debug: {
+                counter += 1;
+                if counter % 500_000 == 0 {
+                    println!("Parsing line #{}...", counter);
+                }
+            }
+
+            let mut line_split = line.split(|&byte| byte == b';');
+
+            if let (Some(name), Some(value_raw), None) =
+                (line_split.next(), line_split.next(), line_split.next())
+            {
+                records.insert(name.into(), parse_value(value_raw));
+            } else {
+                panic!(
+                    "parse_bytes() found an invalid line: {:?}",
+                    func::bytes_to_string(line)
+                );
+            }
+        });
+}
+
+/// Parse value.
+pub fn parse_value(bytes: &[u8]) -> i16 {
+    let mut multiplier: i16 = 1;
+
+    if bytes[0] == b'-' {
+        multiplier = -1;
+    }
+
+    bytes.iter().fold(0, |acc, digit| match *digit {
+        i if i.is_ascii_digit() => acc * 10 + func::u8_to_digit(i) as i16,
+        _ => acc,
+    }) * multiplier
+}

--- a/src/reader/func.rs
+++ b/src/reader/func.rs
@@ -30,32 +30,6 @@ pub fn clone_buffer(buffer_read: &mut [u8], buffer_export: &mut Vec<u8>) {
     buffer_export.extend_from_slice(buffer_read);
 }
 
-/// Push buffer to the queue and reset the buffer.
-pub fn push_buffer(
-    buffer_export: &mut Vec<u8>,
-    queue: &deadqueue::unlimited::Queue<Vec<u8>>,
-) -> usize {
-    if !buffer_export.is_empty() {
-        let mut buffer_new = Vec::<u8>::with_capacity(buffer_export.capacity());
-
-        {
-            #[cfg(feature = "timed")]
-            let _counter = MEM_SWAP_TIMED
-                .get_or_init(|| TimedOperation::new("mem_swap"))
-                .start();
-            std::mem::swap(&mut buffer_new, buffer_export);
-        }
-
-        let len = buffer_new.len();
-        queue.push(buffer_new);
-        len
-    } else {
-        #[cfg(feature = "debug")]
-        println!("RowsReader: push_buffer() skipped empty buffer.");
-        0
-    }
-}
-
 /// Check if the buffer is full.
 pub fn buffer_full(buffer_export: &Vec<u8>, chunk_size: usize) -> bool {
     #[cfg(not(feature = "debug"))]

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -4,3 +4,6 @@ pub mod func;
 
 mod models;
 pub use models::*;
+
+#[cfg(feature = "sync")]
+pub mod sync;

--- a/src/reader/models.rs
+++ b/src/reader/models.rs
@@ -69,6 +69,16 @@ impl RowsReader {
         }
     }
 
+    /// Add additional buffers to the queue.
+    pub fn with_additional_buffers(self, additional_buffers: usize) -> Self {
+        for _ in 0..additional_buffers {
+            self.input_queue
+                .push(Vec::with_capacity(self.max_chunk_size));
+        }
+
+        self
+    }
+
     /// Check if the reader is in progress.
     pub fn in_progress(&self) -> bool {
         self.in_progress.load(Ordering::Relaxed)
@@ -95,7 +105,7 @@ impl RowsReader {
     pub async fn fill(&self, mut buffer: Vec<u8>) -> Option<Vec<u8>> {
         #[cfg(feature = "timed")]
         let _counter = READER_LOCK_TIMED
-            .get_or_init(|| TimedOperation::new("RowsReader::pop()"))
+            .get_or_init(|| TimedOperation::new("RowsReader::fill()"))
             .start();
 
         buffer.clear();

--- a/src/reader/sync.rs
+++ b/src/reader/sync.rs
@@ -1,0 +1,133 @@
+//! Blocking implementations of the reader.
+//!
+use crate::config;
+
+/// Memory-mapped file reader, reading the file in chunks.
+///
+/// This is a synchronous reader, and is used as a baseline for the performance of the
+/// asynchronous reader. This is designed to be an [`Iterator`] over the chunks of [`&[u8]`].
+pub struct MmapReader {
+    mmap: memmap::Mmap,
+    pub chunk_size: usize,
+}
+
+impl MmapReader {
+    /// Create a new instance of the MmapReader using the provided memory-mapped file.
+    pub fn new(mmap: memmap::Mmap) -> Self {
+        Self {
+            mmap,
+            chunk_size: config::CHUNK_SIZE,
+        }
+    }
+
+    /// Set the chunk size for the MmapReader.
+    pub fn with_chunk_size(mut self, chunk_size: usize) -> Self {
+        self.chunk_size = chunk_size;
+        self
+    }
+
+    /// Set the chunk size to split the file evenly into the given number of chunks.
+    pub fn with_chunks(mut self, chunks: usize) -> Self {
+        self.chunk_size =
+            self.mmap.len() / chunks + if self.mmap.len() % chunks > 0 { 1 } else { 0 };
+        self
+    }
+
+    /// Read the provided [`std::fs::File`] using [`MmapReader`].
+    pub fn from_file(file: std::fs::File) -> Self {
+        let mmap = unsafe {
+            memmap::MmapOptions::new()
+                .map(&file)
+                .unwrap_or_else(|_| panic!("Could not memory-map the file at {:?}.", file))
+        };
+
+        Self::new(mmap)
+    }
+
+    /// Read the file at the given path using [`MmapReader`].
+    pub fn from_path(path: &str) -> Self {
+        let file = std::fs::File::open(path)
+            .unwrap_or_else(|_| panic!("Could not open file at path: {}", path));
+        Self::from_file(file)
+    }
+
+    /// Seek from a specific position in the file, until a certain byte is found.
+    /// Returns the position after the byte if found, or None otherwise.
+    ///
+    /// Start of file is deemed to match any bytes; so if `position` is 0,
+    /// the [`Self::seek_from`] will always return [`Some`](`0`).
+    pub fn seek_from(&self, position: usize, byte: u8) -> Option<usize> {
+        if position == 0 {
+            return Some(0);
+        } else if position >= self.mmap.len() {
+            return None;
+        }
+
+        self.mmap[position..]
+            .iter()
+            .enumerate()
+            .find_map(|(offset, &b)| (b == byte).then(|| position + offset + 1))
+    }
+
+    /// Read the next chunk of bytes from the [`MmapReader`], up to the next matching
+    /// byte after the end of the chunk, or the end of the file.
+    ///
+    /// This does NOT check if the starting position makes any sense.
+    pub fn read_from(&self, position: usize, byte: u8) -> Option<&[u8]> {
+        if position >= self.mmap.len() {
+            return None;
+        }
+
+        // End is either the next matching byte, or the end of the file.
+        let end = self
+            .seek_from(position + self.chunk_size, byte)
+            .unwrap_or_else(|| self.mmap.len());
+        let chunk = &self.mmap[position..end];
+
+        Some(chunk)
+    }
+
+    /// Iterate over the chunks of bytes in the memory-mapped file.
+    pub fn iter<const SEP: u8>(&self) -> IterMmapReader<'_, SEP> {
+        IterMmapReader {
+            reader: self,
+            cursor: 0,
+        }
+    }
+
+    /// Get the length of the memory-mapped file.
+    pub fn len(&self) -> usize {
+        self.mmap.len()
+    }
+
+    /// Get the number of chunks in the memory-mapped file.
+    pub fn chunks_count(&self) -> usize {
+        self.len() / self.chunk_size
+            + if self.len() % self.chunk_size > 0 {
+                1
+            } else {
+                0
+            }
+    }
+}
+
+/// An iterator over the chunks of bytes in a memory-mapped file.
+pub struct IterMmapReader<'m, const SEP: u8> {
+    reader: &'m MmapReader,
+    cursor: usize,
+}
+
+impl<'m, const SEP: u8> Iterator for IterMmapReader<'m, SEP> {
+    type Item = &'m [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let chunk = self.reader.read_from(self.cursor, SEP);
+
+        if let Some(chunk) = chunk {
+            self.cursor += chunk.len();
+            Some(chunk)
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
Added a `mmap` + `rayon` implementation using `--bin mmap_baseline`; this allows a somewhat competitive timing (~7.3s), leaving the async implementation to do what I want it to do in the first place, which is a memory-efficient version with no upper limit on input file size.

In the async version, the buffers are now recycled - this allow a precisely predictable amount of memory usage prior to running.